### PR TITLE
Remove mail_confirmation permission (hitobito/hitobito_sac_cas#2399)

### DIFF
--- a/app/abilities/dsj/event/participation_ability.rb
+++ b/app/abilities/dsj/event/participation_ability.rb
@@ -10,22 +10,12 @@ module Dsj::Event::ParticipationAbility
 
   included do
     on(Event::Participation) do
-      permission(:group_full).may(:mail_confirmation).in_same_group_if_active_unless_fundraising
-      # rubocop:todo Layout/LineLength
-      permission(:group_and_below_full).may(:mail_confirmation).in_same_group_or_below_if_active_unless_fundraising
-      # rubocop:enable Layout/LineLength
-      permission(:layer_full).may(:mail_confirmation).in_same_layer_if_active_unless_fundraising
-      # rubocop:todo Layout/LineLength
-      permission(:layer_and_below_full).may(:mail_confirmation).in_same_layer_if_active_unless_fundraising
-      # rubocop:enable Layout/LineLength
-
       permission(:any).may(:print).her_own_or_for_participations_full_events_unless_fundraising
       permission(:group_full).may(:print).in_same_group_unless_fundraising
       permission(:group_and_below_full).may(:print).in_same_group_or_below_unless_fundraising
       permission(:layer_full).may(:print).in_same_layer_or_different_prio_unless_fundraising
-      # rubocop:todo Layout/LineLength
-      permission(:layer_and_below_full).may(:print).in_same_layer_or_below_or_different_prio_unless_fundraising
-      # rubocop:enable Layout/LineLength
+      permission(:layer_and_below_full).may(:print)
+        .in_same_layer_or_below_or_different_prio_unless_fundraising
     end
   end
 

--- a/app/models/event/fundraising.rb
+++ b/app/models/event/fundraising.rb
@@ -6,6 +6,9 @@
 #  https://github.com/hitobito/hitobito_dsj.
 
 class Event::Fundraising < Event
+  self.manually_sendable_participant_mails = []
+  self.manually_sendable_leader_mails = []
+
   self.used_attributes -= [:maximum_participants,
     :location, :application_opening_at,
     :application_closing_at, :application_conditions,

--- a/spec/abilities/event/participation_ability_spec.rb
+++ b/spec/abilities/event/participation_ability_spec.rb
@@ -21,11 +21,6 @@ describe Event::ParticipationAbility do
   context :layer_full do
     let(:role) { Fabricate(Group::JugendparlamentLeitung::Praesidium.name.to_sym, group: groups(:jupa_be_leitung)) }
 
-    it "may send mail confirmation for events unless for fundraisings" do
-      is_expected.to be_able_to(:mail_confirmation, event_participation)
-      is_expected.to_not be_able_to(:mail_confirmation, fundraising_participation)
-    end
-
     it "may print participations unless for fundraisings" do
       is_expected.to be_able_to(:print, event_participation)
       is_expected.to_not be_able_to(:print, fundraising_participation)
@@ -34,11 +29,6 @@ describe Event::ParticipationAbility do
 
   context :group_and_below_full do
     let(:role) { Fabricate(Group::DachverbandProjektgruppe::Leitung.name.to_sym, group: groups(:dachverband_projektgruppe)) }
-
-    it "may send mail confirmation for events unless for fundraisings" do
-      is_expected.to be_able_to(:mail_confirmation, event_participation)
-      is_expected.to_not be_able_to(:mail_confirmation, fundraising_participation)
-    end
 
     it "may print participations unless for fundraisings" do
       is_expected.to be_able_to(:print, event_participation)


### PR DESCRIPTION
This permission is not needed or checked anymore in core. It was introduced to prevent emails being sent for fundraising events, but since manual email sending is now based on event types and fundraising events define none, this permission can be removed.