### PR TITLE
Cleanup collection select calls 🤖

### DIFF
--- a/app/views/events/participation_contact_datas/_fields_dsj.html.haml
+++ b/app/views/events/participation_contact_datas/_fields_dsj.html.haml
@@ -9,7 +9,7 @@
   - if event.show_contact_attr?(:contact_number)
     = f.labeled_input_field :contact_number
   - if event.show_contact_attr?(:salutation)
-    = f.labeled_collection_select :salutation, Salutation.available, :first, :last, { include_blank: "" }, class: 'form-select form-select-sm'
+    = f.labeled_collection_select :salutation, Salutation.available, :first, :last, { include_blank: "" }
   - if event.show_contact_attr?(:salutation_addition)
     = f.labeled_input_field :salutation_addition
 

--- a/app/views/people/_fields_dsj.html.haml
+++ b/app/views/people/_fields_dsj.html.haml
@@ -8,8 +8,7 @@
   = f.labeled_collection_select(:salutation,
                                 Person::SALUTATIONS,
                                 :first, :second,
-                                { include_blank: "" },
-                                { class: 'form-select form-select-sm' })
+                                { include_blank: "" })
   = f.labeled_input_field(:salutation_addition)
   = f.labeled_input_field(:financial_support)
 


### PR DESCRIPTION
Remove now-redundant class: 'form-select form-select-sm' defaults from
collection_select/labeled_collection_select calls, now that
StandardFormBuilder#collection_select applies this class by default.
